### PR TITLE
Add parasite-themed chatbot landing page

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -88,7 +88,7 @@ rt {
 
 .landing {
   margin: 0 auto;
-  padding: 4rem 1.5rem 5rem;
+  padding: clamp(3rem, 6vw, 4rem) clamp(1.1rem, 4vw, 1.5rem) clamp(3.5rem, 8vw, 5rem);
   max-width: 1100px;
 }
 
@@ -551,11 +551,12 @@ rt {
 
 @media (max-width: 960px) {
   .landing {
-    padding-top: 3.5rem;
+    padding-top: clamp(2.5rem, 7vw, 3.5rem);
   }
 
   .chat-layout {
     grid-template-columns: 1fr;
+    gap: 2rem;
   }
 
   .chat-section::before {
@@ -578,8 +579,24 @@ rt {
     inset: -55% -25% -45% -25%;
   }
 
+  .hero__content {
+    text-align: center;
+    margin-inline: auto;
+  }
+
+  .hero__eyebrow {
+    margin-inline: auto;
+  }
+
+  .hero p {
+    font-size: 0.98rem;
+    text-align: left;
+  }
+
   .chat-window__header {
     padding: 1.6rem 1.5rem 1.2rem;
+    flex-direction: column;
+    gap: 1rem;
   }
 
   .chat-window__messages {
@@ -593,9 +610,163 @@ rt {
   .chat-window__form {
     flex-direction: column;
     align-items: stretch;
+    gap: 0.85rem;
   }
 
   .chat-window__send {
     width: 100%;
+  }
+
+  .chat-window__status {
+    align-self: flex-start;
+    justify-content: center;
+  }
+
+  .chat-layout {
+    gap: 1.6rem;
+  }
+
+  .chat-tips {
+    padding: 2.1rem 1.85rem;
+    gap: 1.15rem;
+  }
+}
+
+@media (max-width: 520px) {
+  .landing {
+    padding-inline: clamp(0.9rem, 6vw, 1.25rem);
+  }
+
+  .hero {
+    padding: 2.1rem 1.55rem;
+  }
+
+  .hero h1 {
+    font-size: clamp(2.2rem, 9vw, 2.8rem);
+  }
+
+  .hero__decor {
+    inset: -65% -38% -55% -38%;
+  }
+
+  .hero p {
+    font-size: 0.94rem;
+    padding: 0.95rem 1.1rem;
+  }
+
+  .chat-section {
+    margin-top: 3rem;
+  }
+
+  .chat-window {
+    min-height: 420px;
+  }
+
+  .chat-window__header h2 {
+    font-size: 1.32rem;
+  }
+
+  .chat-window__subhead {
+    font-size: 0.94rem;
+  }
+
+  .chat-window__messages {
+    padding: 1.3rem;
+    gap: 1rem;
+  }
+
+  .chat-window__composer {
+    padding: 1rem 1.1rem 1.5rem;
+  }
+
+  .chat-window__form {
+    padding: 0.8rem 0.9rem;
+    gap: 0.75rem;
+  }
+
+  .chat-window__form input[type="text"] {
+    font-size: 0.98rem;
+  }
+
+  .chat-window__send {
+    padding: 0.6rem 1.4rem;
+  }
+
+  .chat-tips {
+    padding: 1.9rem 1.6rem;
+  }
+
+  .chat-tips ul {
+    gap: 0.85rem;
+  }
+
+  .chat-tips li {
+    padding: 0.95rem 1.1rem 0.95rem 2.3rem;
+  }
+
+  .chat-tips__footer {
+    font-size: 0.84rem;
+  }
+}
+
+@media (max-width: 420px) {
+  body {
+    line-height: 1.55;
+  }
+
+  .landing {
+    padding-top: clamp(2.2rem, 8vw, 2.8rem);
+    padding-bottom: clamp(3rem, 10vw, 4rem);
+  }
+
+  .hero {
+    border-radius: 22px;
+  }
+
+  .hero__eyebrow {
+    font-size: 0.78rem;
+    padding: 0.45rem 1rem;
+  }
+
+  .hero h1 {
+    font-size: clamp(1.95rem, 10vw, 2.4rem);
+  }
+
+  .hero p {
+    font-size: 0.9rem;
+  }
+
+  .chat-window {
+    border-radius: 24px;
+    min-height: 380px;
+  }
+
+  .chat-window__header h2 {
+    font-size: 1.24rem;
+  }
+
+  .chat-window__messages {
+    padding: 1.15rem;
+  }
+
+  .chat-window__form {
+    padding: 0.75rem 0.85rem;
+  }
+
+  .chat-window__send {
+    padding: 0.55rem 1.2rem;
+    font-size: 0.96rem;
+  }
+
+  .message {
+    max-width: 100%;
+  }
+
+  .chat-tips {
+    border-radius: 24px;
+  }
+
+  .chat-tips li::before {
+    left: 0.85rem;
   }
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,10 +1,374 @@
-/*
- * This is a manifest file that'll be compiled into application.css.
- *
- * With Propshaft, assets are served efficiently without preprocessing steps. You can still include
- * application-wide styles in this file, but keep in mind that CSS precedence will follow the standard
- * cascading order, meaning styles declared later in the document or manifest will override earlier ones,
- * depending on specificity.
- *
- * Consider organizing styles into separate files for maintainability.
- */
+:root {
+  color-scheme: dark;
+  --bg-gradient: radial-gradient(circle at top, #184c54 0%, #0d1b1e 35%, #060b0c 100%);
+  --surface-primary: rgba(9, 25, 28, 0.72);
+  --surface-secondary: rgba(13, 35, 39, 0.9);
+  --surface-highlight: rgba(28, 90, 90, 0.65);
+  --border-soft: rgba(94, 192, 191, 0.25);
+  --border-strong: rgba(94, 192, 191, 0.4);
+  --text-primary: #e8fbfb;
+  --text-secondary: rgba(221, 244, 243, 0.75);
+  --accent: #64d4d0;
+  --accent-strong: #7af6d6;
+  --danger: #f58f7c;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Noto Sans JP", "Hiragino Sans", "Yu Gothic", "Segoe UI", sans-serif;
+  color: var(--text-primary);
+  background: var(--bg-gradient);
+  min-height: 100vh;
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+}
+
+main {
+  display: block;
+}
+
+.landing {
+  margin: 0 auto;
+  padding: 4rem 1.5rem 5rem;
+  max-width: 1100px;
+}
+
+.hero {
+  position: relative;
+  padding: 3rem clamp(1.5rem, 2vw + 1rem, 3.5rem);
+  border-radius: 24px;
+  border: 1px solid var(--border-soft);
+  background: linear-gradient(135deg, rgba(14, 50, 54, 0.8), rgba(10, 23, 26, 0.85));
+  overflow: hidden;
+  box-shadow: 0 30px 50px rgba(0, 0, 0, 0.45);
+  margin-bottom: 3.5rem;
+}
+
+.hero__content {
+  position: relative;
+  z-index: 1;
+  max-width: 38rem;
+}
+
+.hero__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-strong);
+  background: rgba(14, 62, 66, 0.6);
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 1.2rem;
+}
+
+.hero h1 {
+  font-size: clamp(2.4rem, 5vw, 3.4rem);
+  margin: 0 0 1rem;
+}
+
+.hero p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 1.05rem;
+}
+
+.hero__glow {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(122, 246, 214, 0.45), transparent 55%),
+    radial-gradient(circle at 80% 30%, rgba(84, 197, 210, 0.35), transparent 60%);
+  filter: blur(12px);
+  opacity: 0.8;
+}
+
+.chat-section {
+  position: relative;
+}
+
+.chat-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  gap: 2.5rem;
+  align-items: start;
+}
+
+.chat-window {
+  background: var(--surface-secondary);
+  border-radius: 22px;
+  border: 1px solid var(--border-soft);
+  box-shadow: 0 25px 40px rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
+  min-height: 520px;
+  overflow: hidden;
+  backdrop-filter: blur(16px);
+}
+
+.chat-window__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+  padding: 1.75rem 2rem 1.25rem;
+  border-bottom: 1px solid rgba(100, 212, 208, 0.2);
+  background: rgba(11, 45, 50, 0.5);
+}
+
+.chat-window__header h2 {
+  font-size: 1.35rem;
+  margin: 0 0 0.35rem;
+}
+
+.chat-window__subhead {
+  color: var(--text-secondary);
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.chat-window__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(68, 196, 183, 0.15);
+  border: 1px solid rgba(122, 246, 214, 0.4);
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+}
+
+.chat-window__messages {
+  flex: 1;
+  padding: 2rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  background: linear-gradient(180deg, rgba(6, 20, 22, 0.9), rgba(6, 16, 17, 0.65));
+}
+
+.chat-window__messages::-webkit-scrollbar {
+  width: 8px;
+}
+
+.chat-window__messages::-webkit-scrollbar-thumb {
+  background: rgba(122, 246, 214, 0.35);
+  border-radius: 999px;
+}
+
+.chat-window__composer {
+  padding: 1.25rem 1.5rem 1.75rem;
+  background: rgba(11, 45, 50, 0.45);
+  border-top: 1px solid rgba(122, 246, 214, 0.2);
+}
+
+.chat-window__form {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  background: rgba(7, 23, 25, 0.8);
+  border-radius: 16px;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(100, 212, 208, 0.2);
+}
+
+.chat-window__form input[type="text"] {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: var(--text-primary);
+  font-size: 1rem;
+  outline: none;
+}
+
+.chat-window__form input::placeholder {
+  color: rgba(200, 236, 235, 0.45);
+}
+
+.chat-window__send {
+  border: none;
+  border-radius: 12px;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #00100f;
+  font-weight: 600;
+  padding: 0.6rem 1.4rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.chat-window__send:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.chat-window__send:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(122, 246, 214, 0.35);
+}
+
+.message {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  max-width: 85%;
+}
+
+.user-message {
+  align-self: flex-end;
+  text-align: right;
+}
+
+.bot-message {
+  align-self: flex-start;
+}
+
+.message-bubble {
+  padding: 1rem 1.2rem;
+  border-radius: 18px;
+  font-size: 0.98rem;
+  letter-spacing: 0.01em;
+  line-height: 1.65;
+  box-shadow: 0 18px 30px rgba(0, 0, 0, 0.35);
+}
+
+.user-message .message-bubble {
+  background: linear-gradient(135deg, rgba(122, 246, 214, 0.9), rgba(91, 205, 218, 0.85));
+  color: #002121;
+}
+
+.bot-message .message-bubble {
+  background: rgba(10, 40, 45, 0.85);
+  border: 1px solid rgba(122, 246, 214, 0.22);
+  color: var(--text-primary);
+}
+
+.message-meta {
+  font-size: 0.75rem;
+  color: rgba(214, 245, 245, 0.45);
+}
+
+.typing-indicator .message-bubble {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  background: rgba(10, 40, 45, 0.7);
+}
+
+.typing-dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background: rgba(122, 246, 214, 0.6);
+  animation: blink 1.4s infinite ease-in-out;
+}
+
+.typing-dot:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.typing-dot:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes blink {
+  0%,
+  80%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.3;
+  }
+  40% {
+    transform: translateY(-3px);
+    opacity: 1;
+  }
+}
+
+.chat-tips {
+  background: var(--surface-primary);
+  border-radius: 22px;
+  padding: 2.25rem;
+  border: 1px solid var(--border-soft);
+  box-shadow: 0 25px 45px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(18px);
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.chat-tips h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.chat-tips ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: var(--text-secondary);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.chat-tips__footer {
+  font-size: 0.85rem;
+  color: rgba(216, 240, 239, 0.6);
+  line-height: 1.5;
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 960px) {
+  .landing {
+    padding-top: 3.5rem;
+  }
+
+  .chat-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .chat-window {
+    min-height: 480px;
+  }
+}
+
+@media (max-width: 600px) {
+  .hero {
+    padding: 2.5rem 1.75rem;
+  }
+
+  .chat-window__header {
+    padding: 1.5rem 1.5rem 1.1rem;
+  }
+
+  .chat-window__messages {
+    padding: 1.5rem;
+  }
+
+  .chat-window__form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .chat-window__send {
+    width: 100%;
+  }
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -104,7 +104,6 @@ rt {
 
 .hero__decor {
   position: absolute;
-  inset: -40% -15% -35% -15%;
   z-index: 0;
 }
 
@@ -154,6 +153,7 @@ rt {
   align-items: center;
   gap: 0.45rem;
   padding: 0.5rem 1.1rem;
+  margin-bottom: 12px;
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.85);
   color: var(--accent);
@@ -203,16 +203,6 @@ rt {
 .chat-section {
   position: relative;
   margin-top: 4rem;
-}
-
-.chat-section::before {
-  content: "";
-  position: absolute;
-  inset: -4rem -12rem -6rem;
-  background: radial-gradient(circle at 30% 10%, rgba(255, 255, 255, 0.32), transparent 60%),
-    radial-gradient(circle at 80% 30%, rgba(255, 255, 255, 0.28), transparent 65%),
-    radial-gradient(circle at 50% 70%, rgba(255, 255, 255, 0.25), transparent 70%);
-  z-index: 0;
 }
 
 .chat-layout {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,16 +1,17 @@
 :root {
-  color-scheme: dark;
-  --bg-gradient: radial-gradient(circle at top, #184c54 0%, #0d1b1e 35%, #060b0c 100%);
-  --surface-primary: rgba(9, 25, 28, 0.72);
-  --surface-secondary: rgba(13, 35, 39, 0.9);
-  --surface-highlight: rgba(28, 90, 90, 0.65);
-  --border-soft: rgba(94, 192, 191, 0.25);
-  --border-strong: rgba(94, 192, 191, 0.4);
-  --text-primary: #e8fbfb;
-  --text-secondary: rgba(221, 244, 243, 0.75);
-  --accent: #64d4d0;
-  --accent-strong: #7af6d6;
-  --danger: #f58f7c;
+  color-scheme: light;
+  --bg-gradient: linear-gradient(135deg, #fef4a0 0%, #ffd1dc 38%, #c7f5ff 100%);
+  --surface-primary: rgba(255, 255, 255, 0.82);
+  --surface-secondary: rgba(255, 255, 255, 0.92);
+  --surface-highlight: rgba(255, 243, 173, 0.85);
+  --border-soft: rgba(255, 255, 255, 0.65);
+  --border-strong: rgba(255, 156, 187, 0.7);
+  --text-primary: #2f2a4a;
+  --text-secondary: rgba(47, 42, 74, 0.72);
+  --accent: #ff87ab;
+  --accent-strong: #ffce6d;
+  --accent-sky: #6ed3ff;
+  --success: #4fcbb0;
 }
 
 *,
@@ -21,11 +22,36 @@
 
 body {
   margin: 0;
-  font-family: "Noto Sans JP", "Hiragino Sans", "Yu Gothic", "Segoe UI", sans-serif;
+  font-family: "M PLUS Rounded 1c", "Hiragino Maru Gothic ProN", "Yu Gothic UI", "Noto Sans JP", sans-serif;
   color: var(--text-primary);
   background: var(--bg-gradient);
   min-height: 100vh;
   line-height: 1.6;
+  position: relative;
+  overflow-x: hidden;
+}
+
+body::before,
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: -1;
+}
+
+body::before {
+  background-image: radial-gradient(circle at 10% 20%, rgba(255, 255, 255, 0.65) 0, transparent 55%),
+    radial-gradient(circle at 85% 15%, rgba(255, 255, 255, 0.5) 0, transparent 60%),
+    radial-gradient(circle at 50% 80%, rgba(255, 255, 255, 0.45) 0, transparent 65%);
+  opacity: 0.55;
+}
+
+body::after {
+  background-image: linear-gradient(135deg, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0) 60%),
+    radial-gradient(circle at 40% 40%, rgba(255, 255, 255, 0.18) 0, transparent 55%),
+    radial-gradient(circle at 75% 70%, rgba(255, 255, 255, 0.2) 0, transparent 55%);
+  opacity: 0.4;
 }
 
 a {
@@ -36,6 +62,30 @@ main {
   display: block;
 }
 
+.ruby-inline,
+ruby {
+  ruby-position: over;
+  white-space: nowrap;
+}
+
+rt {
+  font-size: 0.58em;
+  color: var(--accent);
+  font-weight: 700;
+  letter-spacing: 0.05em;
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
 .landing {
   margin: 0 auto;
   padding: 4rem 1.5rem 5rem;
@@ -44,75 +94,159 @@ main {
 
 .hero {
   position: relative;
-  padding: 3rem clamp(1.5rem, 2vw + 1rem, 3.5rem);
-  border-radius: 24px;
-  border: 1px solid var(--border-soft);
-  background: linear-gradient(135deg, rgba(14, 50, 54, 0.8), rgba(10, 23, 26, 0.85));
+  padding: clamp(2.75rem, 6vw, 4rem);
+  border-radius: 32px;
+  border: 3px solid rgba(255, 255, 255, 0.75);
+  background: linear-gradient(125deg, rgba(255, 255, 255, 0.9) 0%, rgba(255, 230, 247, 0.9) 45%, rgba(210, 244, 255, 0.85) 100%);
   overflow: hidden;
-  box-shadow: 0 30px 50px rgba(0, 0, 0, 0.45);
-  margin-bottom: 3.5rem;
+  box-shadow: 0 30px 60px rgba(255, 170, 206, 0.35);
+}
+
+.hero__decor {
+  position: absolute;
+  inset: -40% -15% -35% -15%;
+  z-index: 0;
+}
+
+.hero__shape {
+  position: absolute;
+  border-radius: 50%;
+  opacity: 0.7;
+  filter: blur(0px);
+  mix-blend-mode: screen;
+  animation: floaty 14s ease-in-out infinite;
+}
+
+.hero__shape--one {
+  width: 380px;
+  height: 380px;
+  top: 12%;
+  left: -6%;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 207, 228, 0.85), rgba(255, 137, 171, 0.6));
+}
+
+.hero__shape--two {
+  width: 260px;
+  height: 260px;
+  right: -8%;
+  top: 48%;
+  animation-delay: -6s;
+  background: radial-gradient(circle at 50% 50%, rgba(110, 211, 255, 0.8), rgba(255, 255, 255, 0));
+}
+
+.hero__shape--three {
+  width: 220px;
+  height: 220px;
+  bottom: -8%;
+  left: 42%;
+  animation-delay: -3s;
+  background: radial-gradient(circle at 40% 40%, rgba(255, 246, 176, 0.85), rgba(255, 255, 255, 0));
 }
 
 .hero__content {
   position: relative;
   z-index: 1;
-  max-width: 38rem;
+  max-width: 40rem;
 }
 
 .hero__eyebrow {
   display: inline-flex;
   align-items: center;
-  padding: 0.35rem 0.9rem;
+  gap: 0.45rem;
+  padding: 0.5rem 1.1rem;
   border-radius: 999px;
-  border: 1px solid var(--border-strong);
-  background: rgba(14, 62, 66, 0.6);
+  background: rgba(255, 255, 255, 0.85);
+  color: var(--accent);
   font-size: 0.85rem;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
-  margin-bottom: 1.2rem;
+  font-weight: 700;
+  box-shadow: 0 15px 24px rgba(255, 135, 171, 0.25);
+}
+
+.hero__eyebrow::before {
+  content: "★";
+  font-size: 0.9rem;
+  color: var(--accent-strong);
 }
 
 .hero h1 {
-  font-size: clamp(2.4rem, 5vw, 3.4rem);
-  margin: 0 0 1rem;
+  font-size: clamp(2.6rem, 6vw, 3.6rem);
+  margin: 0 0 1.25rem;
+  line-height: 1.15;
+  font-weight: 800;
+  background: linear-gradient(90deg, #ff87ab 0%, #ffce6d 50%, #6ed3ff 100%);
+  -webkit-background-clip: text;
+  color: transparent;
+  text-shadow: 0 18px 40px rgba(255, 135, 171, 0.45);
+}
+
+.hero__sparkle {
+  display: inline-block;
+  margin-left: 0.45rem;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  color: #ffd966;
+  transform: rotate(-15deg);
+  animation: twinkle 2.4s ease-in-out infinite;
 }
 
 .hero p {
   margin: 0;
   color: var(--text-secondary);
   font-size: 1.05rem;
-}
-
-.hero__glow {
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at 20% 20%, rgba(122, 246, 214, 0.45), transparent 55%),
-    radial-gradient(circle at 80% 30%, rgba(84, 197, 210, 0.35), transparent 60%);
-  filter: blur(12px);
-  opacity: 0.8;
+  background: rgba(255, 255, 255, 0.78);
+  border-radius: 18px;
+  padding: 1.05rem 1.35rem;
+  box-shadow: 0 18px 28px rgba(110, 211, 255, 0.25);
 }
 
 .chat-section {
   position: relative;
+  margin-top: 4rem;
+}
+
+.chat-section::before {
+  content: "";
+  position: absolute;
+  inset: -4rem -12rem -6rem;
+  background: radial-gradient(circle at 30% 10%, rgba(255, 255, 255, 0.32), transparent 60%),
+    radial-gradient(circle at 80% 30%, rgba(255, 255, 255, 0.28), transparent 65%),
+    radial-gradient(circle at 50% 70%, rgba(255, 255, 255, 0.25), transparent 70%);
+  z-index: 0;
 }
 
 .chat-layout {
+  position: relative;
+  z-index: 1;
   display: grid;
   grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
-  gap: 2.5rem;
+  gap: 2.75rem;
   align-items: start;
 }
 
 .chat-window {
+  position: relative;
   background: var(--surface-secondary);
-  border-radius: 22px;
-  border: 1px solid var(--border-soft);
-  box-shadow: 0 25px 40px rgba(0, 0, 0, 0.35);
+  border-radius: 28px;
+  border: 3px solid rgba(255, 255, 255, 0.85);
+  box-shadow: 0 28px 60px rgba(255, 170, 206, 0.3);
   display: flex;
   flex-direction: column;
   min-height: 520px;
   overflow: hidden;
-  backdrop-filter: blur(16px);
+}
+
+.chat-window::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.95), rgba(255, 238, 252, 0.82));
+  z-index: 0;
+}
+
+.chat-window > * {
+  position: relative;
+  z-index: 1;
 }
 
 .chat-window__header {
@@ -120,32 +254,47 @@ main {
   justify-content: space-between;
   align-items: flex-start;
   gap: 1.5rem;
-  padding: 1.75rem 2rem 1.25rem;
-  border-bottom: 1px solid rgba(100, 212, 208, 0.2);
-  background: rgba(11, 45, 50, 0.5);
+  padding: 1.8rem 2rem 1.4rem;
+  background: linear-gradient(135deg, rgba(255, 240, 200, 0.95), rgba(255, 200, 230, 0.9));
+  border-bottom: 2px dashed rgba(255, 196, 210, 0.55);
 }
 
 .chat-window__header h2 {
-  font-size: 1.35rem;
-  margin: 0 0 0.35rem;
+  font-size: 1.45rem;
+  margin: 0 0 0.45rem;
+  color: #5b2f6f;
+  font-weight: 800;
 }
 
 .chat-window__subhead {
-  color: var(--text-secondary);
+  color: rgba(91, 47, 111, 0.72);
   margin: 0;
-  font-size: 0.95rem;
+  font-size: 0.98rem;
+  font-weight: 600;
 }
 
 .chat-window__status {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.35rem 0.9rem;
+  padding: 0.5rem 1.2rem;
   border-radius: 999px;
-  background: rgba(68, 196, 183, 0.15);
-  border: 1px solid rgba(122, 246, 214, 0.4);
-  font-size: 0.85rem;
-  letter-spacing: 0.02em;
+  background: rgba(79, 203, 176, 0.18);
+  border: 2px solid rgba(79, 203, 176, 0.35);
+  font-size: 0.9rem;
+  letter-spacing: 0.04em;
+  font-weight: 700;
+  color: #178d76;
+  box-shadow: 0 14px 24px rgba(79, 203, 176, 0.22);
+}
+
+.chat-window__status::before {
+  content: "";
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 50%;
+  background: var(--success);
+  box-shadow: 0 0 0 4px rgba(79, 203, 176, 0.18);
 }
 
 .chat-window__messages {
@@ -155,32 +304,33 @@ main {
   display: flex;
   flex-direction: column;
   gap: 1.2rem;
-  background: linear-gradient(180deg, rgba(6, 20, 22, 0.9), rgba(6, 16, 17, 0.65));
+  background: rgba(255, 255, 255, 0.75);
 }
 
 .chat-window__messages::-webkit-scrollbar {
-  width: 8px;
+  width: 10px;
 }
 
 .chat-window__messages::-webkit-scrollbar-thumb {
-  background: rgba(122, 246, 214, 0.35);
+  background: rgba(255, 135, 171, 0.35);
   border-radius: 999px;
 }
 
 .chat-window__composer {
-  padding: 1.25rem 1.5rem 1.75rem;
-  background: rgba(11, 45, 50, 0.45);
-  border-top: 1px solid rgba(122, 246, 214, 0.2);
+  padding: 1.3rem 1.6rem 1.85rem;
+  background: rgba(255, 240, 250, 0.72);
+  border-top: 2px dashed rgba(255, 196, 210, 0.55);
 }
 
 .chat-window__form {
   display: flex;
   gap: 1rem;
   align-items: center;
-  background: rgba(7, 23, 25, 0.8);
-  border-radius: 16px;
-  padding: 0.75rem 1rem;
-  border: 1px solid rgba(100, 212, 208, 0.2);
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 20px;
+  padding: 0.85rem 1rem;
+  border: 2px solid rgba(255, 196, 210, 0.65);
+  box-shadow: 0 15px 28px rgba(255, 170, 206, 0.22);
 }
 
 .chat-window__form input[type="text"] {
@@ -189,32 +339,37 @@ main {
   border: none;
   color: var(--text-primary);
   font-size: 1rem;
+  font-weight: 500;
   outline: none;
 }
 
 .chat-window__form input::placeholder {
-  color: rgba(200, 236, 235, 0.45);
+  color: rgba(91, 47, 111, 0.4);
 }
 
 .chat-window__send {
   border: none;
-  border-radius: 12px;
+  border-radius: 999px;
   background: linear-gradient(135deg, var(--accent), var(--accent-strong));
-  color: #00100f;
-  font-weight: 600;
-  padding: 0.6rem 1.4rem;
+  color: #fffaf3;
+  font-weight: 700;
+  font-size: 1rem;
+  padding: 0.65rem 1.6rem;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+  letter-spacing: 0.05em;
+  box-shadow: 0 15px 25px rgba(255, 135, 171, 0.4);
+  transition: transform 0.25s ease, box-shadow 0.25s ease, opacity 0.25s ease;
 }
 
 .chat-window__send:disabled {
-  opacity: 0.5;
+  opacity: 0.55;
   cursor: not-allowed;
+  box-shadow: none;
 }
 
 .chat-window__send:not(:disabled):hover {
-  transform: translateY(-1px);
-  box-shadow: 0 10px 20px rgba(122, 246, 214, 0.35);
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 20px 32px rgba(255, 135, 171, 0.45);
 }
 
 .message {
@@ -235,41 +390,47 @@ main {
 
 .message-bubble {
   padding: 1rem 1.2rem;
-  border-radius: 18px;
-  font-size: 0.98rem;
+  border-radius: 22px;
+  font-size: 1rem;
   letter-spacing: 0.01em;
   line-height: 1.65;
-  box-shadow: 0 18px 30px rgba(0, 0, 0, 0.35);
+  position: relative;
 }
 
 .user-message .message-bubble {
-  background: linear-gradient(135deg, rgba(122, 246, 214, 0.9), rgba(91, 205, 218, 0.85));
-  color: #002121;
+  background: linear-gradient(135deg, rgba(255, 218, 121, 0.95), rgba(255, 170, 206, 0.9));
+  color: #5b3262;
+  border-radius: 22px 22px 10px 22px;
+  box-shadow: 0 18px 28px rgba(255, 170, 206, 0.28);
 }
 
 .bot-message .message-bubble {
-  background: rgba(10, 40, 45, 0.85);
-  border: 1px solid rgba(122, 246, 214, 0.22);
-  color: var(--text-primary);
+  background: rgba(206, 243, 255, 0.92);
+  border: 2px solid rgba(110, 211, 255, 0.45);
+  color: #1d3b57;
+  border-radius: 22px 22px 22px 10px;
+  box-shadow: 0 18px 28px rgba(110, 211, 255, 0.25);
 }
 
 .message-meta {
-  font-size: 0.75rem;
-  color: rgba(214, 245, 245, 0.45);
+  font-size: 0.78rem;
+  color: rgba(47, 42, 74, 0.45);
+  font-weight: 600;
 }
 
 .typing-indicator .message-bubble {
   display: inline-flex;
-  gap: 0.4rem;
+  gap: 0.45rem;
   align-items: center;
-  background: rgba(10, 40, 45, 0.7);
+  background: rgba(206, 243, 255, 0.85);
+  border: 2px dashed rgba(110, 211, 255, 0.45);
 }
 
 .typing-dot {
-  width: 0.55rem;
-  height: 0.55rem;
+  width: 0.6rem;
+  height: 0.6rem;
   border-radius: 50%;
-  background: rgba(122, 246, 214, 0.6);
+  background: rgba(110, 211, 255, 0.8);
   animation: blink 1.4s infinite ease-in-out;
 }
 
@@ -279,6 +440,78 @@ main {
 
 .typing-dot:nth-child(3) {
   animation-delay: 0.4s;
+}
+
+.chat-tips {
+  position: relative;
+  background: var(--surface-primary);
+  border-radius: 28px;
+  padding: 2.5rem 2.2rem;
+  border: 3px solid rgba(255, 255, 255, 0.85);
+  box-shadow: 0 30px 60px rgba(110, 211, 255, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+  overflow: hidden;
+}
+
+.chat-tips::before {
+  content: "";
+  position: absolute;
+  inset: -40% -30% auto -20%;
+  height: 70%;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 206, 227, 0.6), transparent 60%);
+  pointer-events: none;
+}
+
+.chat-tips h3 {
+  margin: 0;
+  font-size: 1.3rem;
+  font-weight: 800;
+  color: #5b2f6f;
+  background: linear-gradient(90deg, #ff87ab, #6ed3ff);
+  -webkit-background-clip: text;
+  color: transparent;
+}
+
+.chat-tips ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+  color: var(--text-primary);
+}
+
+.chat-tips li {
+  position: relative;
+  padding: 1rem 1.25rem 1rem 2.6rem;
+  background: rgba(255, 255, 255, 0.72);
+  border-radius: 20px;
+  box-shadow: 0 15px 25px rgba(110, 211, 255, 0.22);
+}
+
+.chat-tips li::before {
+  content: "";
+  position: absolute;
+  left: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 1.35rem;
+  height: 1.35rem;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent), var(--accent-sky));
+  box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.7);
+}
+
+.chat-tips__footer {
+  font-size: 0.88rem;
+  color: rgba(47, 42, 74, 0.6);
+  line-height: 1.6;
+  background: rgba(255, 255, 255, 0.7);
+  padding: 0.9rem 1.1rem;
+  border-radius: 16px;
+  box-shadow: 0 12px 24px rgba(255, 206, 227, 0.2);
 }
 
 @keyframes blink {
@@ -294,46 +527,26 @@ main {
   }
 }
 
-.chat-tips {
-  background: var(--surface-primary);
-  border-radius: 22px;
-  padding: 2.25rem;
-  border: 1px solid var(--border-soft);
-  box-shadow: 0 25px 45px rgba(0, 0, 0, 0.35);
-  backdrop-filter: blur(18px);
-  display: flex;
-  flex-direction: column;
-  gap: 1.2rem;
+@keyframes floaty {
+  0%,
+  100% {
+    transform: translateY(0) scale(1);
+  }
+  50% {
+    transform: translateY(-20px) scale(1.05);
+  }
 }
 
-.chat-tips h3 {
-  margin: 0;
-  font-size: 1.2rem;
-}
-
-.chat-tips ul {
-  margin: 0;
-  padding-left: 1.2rem;
-  color: var(--text-secondary);
-  display: grid;
-  gap: 0.75rem;
-}
-
-.chat-tips__footer {
-  font-size: 0.85rem;
-  color: rgba(216, 240, 239, 0.6);
-  line-height: 1.5;
-}
-
-.visually-hidden {
-  position: absolute !important;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  border: 0;
+@keyframes twinkle {
+  0%,
+  100% {
+    transform: rotate(-15deg) scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: rotate(-15deg) scale(1.15);
+    opacity: 0.6;
+  }
 }
 
 @media (max-width: 960px) {
@@ -345,22 +558,36 @@ main {
     grid-template-columns: 1fr;
   }
 
-  .chat-window {
-    min-height: 480px;
+  .chat-section::before {
+    inset: -3rem -8rem -4rem;
+  }
+
+  .chat-window,
+  .chat-tips {
+    box-shadow: 0 20px 45px rgba(110, 211, 255, 0.25);
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width: 680px) {
   .hero {
-    padding: 2.5rem 1.75rem;
+    padding: 2.5rem 1.85rem;
+    border-radius: 26px;
+  }
+
+  .hero__decor {
+    inset: -55% -25% -45% -25%;
   }
 
   .chat-window__header {
-    padding: 1.5rem 1.5rem 1.1rem;
+    padding: 1.6rem 1.5rem 1.2rem;
   }
 
   .chat-window__messages {
-    padding: 1.5rem;
+    padding: 1.6rem;
+  }
+
+  .chat-window__composer {
+    padding: 1.1rem 1.3rem 1.6rem;
   }
 
   .chat-window__form {

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,0 +1,3 @@
+class HomeController < ApplicationController
+  def index; end
+end

--- a/app/javascript/controllers/chat_controller.js
+++ b/app/javascript/controllers/chat_controller.js
@@ -1,0 +1,210 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["messages", "input", "status", "send"]
+
+  connect() {
+    this.typingElement = null
+    this.knowledgeBase = this.buildKnowledgeBase()
+    this.fallbackResponses = this.buildFallbackResponses()
+    this.greet()
+
+    if (this.hasInputTarget) {
+      this.inputTarget.focus()
+    }
+  }
+
+  submit(event) {
+    event.preventDefault()
+    const question = this.inputTarget.value.trim()
+
+    if (!question) {
+      return
+    }
+
+    this.addMessage(question, "user")
+    this.inputTarget.value = ""
+    this.respondTo(question)
+  }
+
+  greet() {
+    const welcome = "ようこそ、寄生虫の世界へ。感染経路から研究の最前線まで、気になるテーマを教えてください。"
+    const hint = "気になっている生物名や症状、予防策などをキーワードで入力すると、寄生虫コンシェルジュが解説します。"
+
+    this.addMessage(welcome, "bot")
+    this.addMessage(hint, "bot")
+  }
+
+  respondTo(question) {
+    this.toggleInteraction(false)
+    this.showTypingIndicator()
+
+    const response = this.generateResponse(question)
+    const delay = 600 + Math.random() * 900
+
+    window.setTimeout(() => {
+      this.hideTypingIndicator()
+      this.addMessage(response, "bot")
+      this.toggleInteraction(true)
+    }, delay)
+  }
+
+  toggleInteraction(enabled) {
+    this.inputTarget.disabled = !enabled
+
+    if (this.hasSendTarget) {
+      this.sendTarget.disabled = !enabled
+    }
+
+    if (this.hasStatusTarget) {
+      this.statusTarget.textContent = enabled ? "オンライン" : "考え中…"
+    }
+
+    if (enabled) {
+      this.inputTarget.focus()
+    }
+  }
+
+  showTypingIndicator() {
+    if (this.typingElement) {
+      return
+    }
+
+    const wrapper = document.createElement("div")
+    wrapper.classList.add("message", "bot-message", "typing-indicator")
+
+    const bubble = document.createElement("div")
+    bubble.classList.add("message-bubble")
+
+    for (let index = 0; index < 3; index += 1) {
+      const dot = document.createElement("span")
+      dot.classList.add("typing-dot")
+      bubble.appendChild(dot)
+    }
+
+    wrapper.appendChild(bubble)
+    this.messagesTarget.appendChild(wrapper)
+    this.typingElement = wrapper
+    this.scrollToBottom()
+  }
+
+  hideTypingIndicator() {
+    if (!this.typingElement) {
+      return
+    }
+
+    this.typingElement.remove()
+    this.typingElement = null
+  }
+
+  addMessage(text, author) {
+    const wrapper = document.createElement("div")
+    wrapper.classList.add("message", `${author}-message`)
+
+    const bubble = document.createElement("div")
+    bubble.classList.add("message-bubble")
+    bubble.textContent = text
+
+    const meta = document.createElement("time")
+    meta.classList.add("message-meta")
+    const timestamp = new Date()
+    meta.dateTime = timestamp.toISOString()
+    meta.textContent = timestamp.toLocaleTimeString("ja-JP", {
+      hour: "2-digit",
+      minute: "2-digit",
+    })
+
+    wrapper.appendChild(bubble)
+    wrapper.appendChild(meta)
+
+    this.messagesTarget.appendChild(wrapper)
+    this.scrollToBottom()
+  }
+
+  scrollToBottom() {
+    this.messagesTarget.scrollTop = this.messagesTarget.scrollHeight
+  }
+
+  generateResponse(question) {
+    const normalized = question.toLowerCase()
+
+    if (/こんにちは|こんばんは|おはよう|hi|hello|hey/.test(normalized)) {
+      return "こんにちは。寄生虫にまつわる疑問があれば、遠慮なく聞いてください。"
+    }
+
+    if (/ありがとう|助か/i.test(normalized)) {
+      return "お役に立ててうれしいです。気になることがあれば、引き続きどうぞ。"
+    }
+
+    if (/さようなら|またね|bye|see you/.test(normalized)) {
+      return "またお会いしましょう。感染症対策はこまめな手洗いと正しい食品管理から。"
+    }
+
+    for (const entry of this.knowledgeBase) {
+      if (entry.keywords.some((pattern) => pattern.test(normalized))) {
+        return entry.response
+      }
+    }
+
+    return this.randomFallback()
+  }
+
+  buildKnowledgeBase() {
+    return [
+      {
+        keywords: [/生活環/, /ライフサイクル/, /life cycle/],
+        response: "多くの寄生虫は複数の宿主を経由する生活環を持っています。例として、マラリア原虫は蚊とヒトを行き来しながら増殖し、成熟段階でそれぞれの体内環境を巧みに利用します。",
+      },
+      {
+        keywords: [/予防/, /対策/, /防ぎ/],
+        response: "寄生虫感染の基本的な予防策は、手洗い・食材の十分な加熱・安全な飲料水の確保です。特に魚介類は-20℃以下で24時間以上冷凍することでアニサキスなどのリスクを大幅に下げられます。",
+      },
+      {
+        keywords: [/症状/, /体調/, /具合/, /symptom/],
+        response: "寄生虫の種類によって症状はさまざまですが、腹痛・下痢・発熱・皮膚のかゆみなどがよく報告されています。強い症状や心配がある場合は自己判断せず医療機関を受診しましょう。",
+      },
+      {
+        keywords: [/アニサキス/, /anisakis/],
+        response: "アニサキスは主にサバやイカなどの生食で感染します。摂取後数時間で胃の激痛を引き起こすことがあり、内視鏡で虫体を摘出する治療が一般的です。加熱または冷凍で予防が可能です。",
+      },
+      {
+        keywords: [/エキノコックス/, /echinococcus/],
+        response: "エキノコックスはキツネなどの糞便を介して卵が撒かれ、ヒトが経口感染すると肝臓に嚢胞を作ります。北海道などの流行地域では野山で拾った山菜や水を生で口にしないことが重要です。",
+      },
+      {
+        keywords: [/マラリア/, /plasmodium/],
+        response: "マラリア原虫はハマダラカが媒介します。熱帯への渡航時には防蚊対策と抗マラリア薬の予防内服が推奨され、早期診断・治療で重症化を防ぎます。",
+      },
+      {
+        keywords: [/寄生蜂/, /ゾンビ蟻/, /操/, /コントロール/, /操作/],
+        response: "行動操作型寄生虫として有名なのがハリガネムシやゾンビアリ現象です。寄生虫は宿主の神経伝達を巧みに操り、次の宿主へ感染しやすい行動を引き出します。生態学の研究ではホルモン制御や遺伝子発現の変化が注目されています。",
+      },
+      {
+        keywords: [/駆除/, /治療/, /薬/, /駆虫/, /treatment/],
+        response: "駆虫薬には虫体の代謝や筋肉機能を狙うものが多く、メトロニダゾール、アルベンダゾール、プラジカンテルなどが代表例です。薬剤選択は寄生虫の種類と感染部位で異なるため、専門医の指示が必要です。",
+      },
+      {
+        keywords: [/寄生虫学/, /研究/, /最新/, /アップデート/, /study/],
+        response: "寄生虫学は医療だけでなく、生態系のバランスや進化の研究にも欠かせない分野です。近年はゲノム解析が進み、薬剤耐性や寄生適応の遺伝的背景が解明されつつあります。",
+      },
+      {
+        keywords: [/寄生虫.*面白い/, /好き/, /興味/, /なんで.*大事/],
+        response: "寄生虫は宿主との共生関係を通じて進化のダイナミクスを教えてくれる存在です。厳しい環境で生き抜く戦略や、宿主との複雑な相互作用は、生命の多様性そのものと言えます。",
+      },
+    ]
+  }
+
+  buildFallbackResponses() {
+    return [
+      "詳しい情報を探しています。もう少し具体的なキーワードや気になる寄生虫の名前を教えてください。",
+      "寄生虫の生活史、症状、予防策など、知りたい観点を伝えていただければ、より的確にお答えできます。",
+      "面白い観点ですね。関連する宿主や感染場所を教えていただくと、さらに深掘りした説明ができますよ。",
+      "専門的な内容の場合は文献名や地域を指定すると調査のヒントになります。ぜひ追加情報をお願いします。",
+    ]
+  }
+
+  randomFallback() {
+    const index = Math.floor(Math.random() * this.fallbackResponses.length)
+    return this.fallbackResponses[index]
+  }
+}

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,0 +1,53 @@
+<% content_for :title, "寄生虫チャットボット" %>
+
+<main class="landing">
+  <section class="hero">
+    <div class="hero__content">
+      <span class="hero__eyebrow">Parasite Navigator</span>
+      <h1>寄生虫チャットボット</h1>
+      <p>
+        寄生虫の世界を案内するバーチャルアシスタントです。生活環、感染経路、予防策など、
+        気になることを何でも質問してください。怖いだけじゃない寄生虫の生態を、好奇心と科学で紐解きましょう。
+      </p>
+    </div>
+    <div class="hero__glow" aria-hidden="true"></div>
+  </section>
+
+  <section class="chat-section" aria-labelledby="chatbot-heading">
+    <div class="chat-layout">
+      <div class="chat-window" data-controller="chat">
+        <div class="chat-window__header">
+          <div>
+            <h2 id="chatbot-heading">寄生虫コンシェルジュ</h2>
+            <p class="chat-window__subhead">寄生虫博士の視点からリアルタイムでガイドします。</p>
+          </div>
+          <span class="chat-window__status" data-chat-target="status">オンライン</span>
+        </div>
+        <div class="chat-window__messages" data-chat-target="messages" aria-live="polite"></div>
+        <div class="chat-window__composer">
+          <form data-action="submit->chat#submit" class="chat-window__form" autocomplete="off">
+            <label for="chat-input" class="visually-hidden">質問を入力</label>
+            <input
+              id="chat-input"
+              type="text"
+              placeholder="例：魚から感染する寄生虫は？"
+              data-chat-target="input"
+              aria-label="寄生虫チャットボットへの質問"
+            >
+            <button type="submit" class="chat-window__send" data-chat-target="send">送信</button>
+          </form>
+        </div>
+      </div>
+
+      <aside class="chat-tips" aria-label="寄生虫の豆知識">
+        <h3>寄生虫の豆知識</h3>
+        <ul>
+          <li>寄生虫は宿主から栄養を得る生物で、医療・生態学の重要な研究対象です。</li>
+          <li>加熱や冷凍など正しい食品管理で、多くの寄生虫感染を防ぐことができます。</li>
+          <li>一部の寄生虫は宿主の行動を巧みに操ることで生存戦略を成功させます。</li>
+        </ul>
+        <p class="chat-tips__footer">チャットでの回答は教育目的です。体調に不安がある場合は医療機関に相談しましょう。</p>
+      </aside>
+    </div>
+  </section>
+</main>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,16 +1,31 @@
-<% content_for :title, "寄生虫チャットボット" %>
+<% content_for :title, "寄生虫（きせいちゅう）チャットボット" %>
 
 <main class="landing">
   <section class="hero">
+    <div class="hero__decor" aria-hidden="true">
+      <span class="hero__shape hero__shape--one"></span>
+      <span class="hero__shape hero__shape--two"></span>
+      <span class="hero__shape hero__shape--three"></span>
+    </div>
     <div class="hero__content">
       <span class="hero__eyebrow">Parasite Navigator</span>
-      <h1>寄生虫チャットボット</h1>
+      <h1>
+        <ruby><rb>寄生虫</rb><rt>きせいちゅう</rt></ruby>
+        チャットボット
+        <span class="hero__sparkle" aria-hidden="true">★</span>
+      </h1>
       <p>
-        寄生虫の世界を案内するバーチャルアシスタントです。生活環、感染経路、予防策など、
-        気になることを何でも質問してください。怖いだけじゃない寄生虫の生態を、好奇心と科学で紐解きましょう。
+        <ruby><rb>寄生虫</rb><rt>きせいちゅう</rt></ruby>の<ruby><rb>世界</rb><rt>せかい</rt></ruby>を
+        <ruby><rb>案内</rb><rt>あんない</rt></ruby>するバーチャルアシスタントです。
+        <ruby><rb>生活環</rb><rt>せいかつかん</rt></ruby>や<ruby><rb>感染</rb><rt>かんせん</rt></ruby>の
+        <ruby><rb>経路</rb><rt>けいろ</rt></ruby>、<ruby><rb>予防策</rb><rt>よぼうさく</rt></ruby>など、
+        <ruby><rb>気</rb><rt>き</rt></ruby>になることをなんでも<ruby><rb>質問</rb><rt>しつもん</rt></ruby>してね。
+        <ruby><rb>怖い</rb><rt>こわい</rt></ruby>だけじゃない
+        <ruby><rb>寄生虫</rb><rt>きせいちゅう</rt></ruby>の<ruby><rb>生態</rb><rt>せいたい</rt></ruby>を、
+        <ruby><rb>好奇心</rb><rt>こうきしん</rt></ruby>と<ruby><rb>科学</rb><rt>かがく</rt></ruby>で
+        <ruby><rb>紐解</rb><rt>ひもと</rt></ruby>いていきましょう。
       </p>
     </div>
-    <div class="hero__glow" aria-hidden="true"></div>
   </section>
 
   <section class="chat-section" aria-labelledby="chatbot-heading">
@@ -18,35 +33,69 @@
       <div class="chat-window" data-controller="chat">
         <div class="chat-window__header">
           <div>
-            <h2 id="chatbot-heading">寄生虫コンシェルジュ</h2>
-            <p class="chat-window__subhead">寄生虫博士の視点からリアルタイムでガイドします。</p>
+            <h2 id="chatbot-heading">
+              <ruby><rb>寄生虫</rb><rt>きせいちゅう</rt></ruby>
+              <ruby><rb>コンシェルジュ</rb><rt>こんしぇるじゅ</rt></ruby>
+            </h2>
+            <p class="chat-window__subhead">
+              <ruby><rb>寄生虫</rb><rt>きせいちゅう</rt></ruby>
+              <ruby><rb>博士</rb><rt>はかせ</rt></ruby>の<ruby><rb>視点</rb><rt>してん</rt></ruby>から
+              リアルタイムでガイドします。
+            </p>
           </div>
           <span class="chat-window__status" data-chat-target="status">オンライン</span>
         </div>
         <div class="chat-window__messages" data-chat-target="messages" aria-live="polite"></div>
         <div class="chat-window__composer">
           <form data-action="submit->chat#submit" class="chat-window__form" autocomplete="off">
-            <label for="chat-input" class="visually-hidden">質問を入力</label>
+            <label for="chat-input" class="visually-hidden">しつもんをいれてね</label>
             <input
               id="chat-input"
               type="text"
-              placeholder="例：魚から感染する寄生虫は？"
+              placeholder="れい：さかなからうつるきせいちゅうは？"
               data-chat-target="input"
-              aria-label="寄生虫チャットボットへの質問"
+              aria-label="きせいちゅうちゃっとぼっとへのしつもん"
             >
-            <button type="submit" class="chat-window__send" data-chat-target="send">送信</button>
+            <button type="submit" class="chat-window__send" data-chat-target="send">おくる</button>
           </form>
         </div>
       </div>
 
-      <aside class="chat-tips" aria-label="寄生虫の豆知識">
-        <h3>寄生虫の豆知識</h3>
+      <aside class="chat-tips" aria-label="きせいちゅうのまめちしき">
+        <h3>
+          <ruby><rb>寄生虫</rb><rt>きせいちゅう</rt></ruby>の
+          <ruby><rb>豆知識</rb><rt>まめちしき</rt></ruby>
+        </h3>
         <ul>
-          <li>寄生虫は宿主から栄養を得る生物で、医療・生態学の重要な研究対象です。</li>
-          <li>加熱や冷凍など正しい食品管理で、多くの寄生虫感染を防ぐことができます。</li>
-          <li>一部の寄生虫は宿主の行動を巧みに操ることで生存戦略を成功させます。</li>
+          <li>
+            <ruby><rb>寄生虫</rb><rt>きせいちゅう</rt></ruby>は
+            <ruby><rb>宿主</rb><rt>やどぬし</rt></ruby>から<ruby><rb>栄養</rb><rt>えいよう</rt></ruby>を
+            <ruby><rb>得</rb><rt>え</rt></ruby>る<ruby><rb>生物</rb><rt>せいぶつ</rt></ruby>で、
+            <ruby><rb>医療</rb><rt>いりょう</rt></ruby>・<ruby><rb>生態学</rb><rt>せいたいがく</rt></ruby>の
+            <ruby><rb>重要</rb><rt>じゅうよう</rt></ruby>な<ruby><rb>研究対象</rb><rt>けんきゅうたいしょう</rt></ruby>です。
+          </li>
+          <li>
+            <ruby><rb>加熱</rb><rt>かねつ</rt></ruby>や<ruby><rb>冷凍</rb><rt>れいとう</rt></ruby>など
+            <ruby><rb>正</rb><rt>ただ</rt></ruby>しい<ruby><rb>食品管理</rb><rt>しょくひんかんり</rt></ruby>で、
+            たくさんの<ruby><rb>寄生虫</rb><rt>きせいちゅう</rt></ruby><ruby><rb>感染</rb><rt>かんせん</rt></ruby>を
+            <ruby><rb>防</rb><rt>ふせ</rt></ruby>ぐことができます。
+          </li>
+          <li>
+            <ruby><rb>一部</rb><rt>いちぶ</rt></ruby>の
+            <ruby><rb>寄生虫</rb><rt>きせいちゅう</rt></ruby>は<ruby><rb>宿主</rb><rt>やどぬし</rt></ruby>の
+            <ruby><rb>行動</rb><rt>こうどう</rt></ruby>を<ruby><rb>巧</rb><rt>たく</rt></ruby>みに
+            <ruby><rb>操</rb><rt>あやつ</rt></ruby>って
+            <ruby><rb>生存戦略</rb><rt>せいぞんせんりゃく</rt></ruby>を
+            <ruby><rb>成功</rb><rt>せいこう</rt></ruby>させます。
+          </li>
         </ul>
-        <p class="chat-tips__footer">チャットでの回答は教育目的です。体調に不安がある場合は医療機関に相談しましょう。</p>
+        <p class="chat-tips__footer">
+          チャットでの<ruby><rb>回答</rb><rt>かいとう</rt></ruby>は
+          <ruby><rb>教育目的</rb><rt>きょういくもくてき</rt></ruby>です。
+          <ruby><rb>体調</rb><rt>たいちょう</rt></ruby>に<ruby><rb>不安</rb><rt>ふあん</rt></ruby>があるときは
+          <ruby><rb>医療機関</rb><rt>いりょうきかん</rt></ruby>に
+          <ruby><rb>相談</rb><rt>そうだん</rt></ruby>しましょう。
+        </p>
       </aside>
     </div>
   </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,5 +10,5 @@ Rails.application.routes.draw do
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
   # Defines the root path route ("/")
-  # root "posts#index"
+  root "home#index"
 end


### PR DESCRIPTION
## Summary
- add a Home controller and root route for a new parasite-focused landing page
- implement a Stimulus-powered chatbot interface that surfaces curated parasite knowledge
- style the top page with a dark, bio-luminescent theme and supporting parasite trivia panel

## Testing
- bin/rails test *(fails: missing required gems in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8fd627a448322b0c94d04d155446c