### PR TITLE
Make landing page kid friendly with furigana

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,16 +1,17 @@
 :root {
-  color-scheme: dark;
-  --bg-gradient: radial-gradient(circle at top, #184c54 0%, #0d1b1e 35%, #060b0c 100%);
-  --surface-primary: rgba(9, 25, 28, 0.72);
-  --surface-secondary: rgba(13, 35, 39, 0.9);
-  --surface-highlight: rgba(28, 90, 90, 0.65);
-  --border-soft: rgba(94, 192, 191, 0.25);
-  --border-strong: rgba(94, 192, 191, 0.4);
-  --text-primary: #e8fbfb;
-  --text-secondary: rgba(221, 244, 243, 0.75);
-  --accent: #64d4d0;
-  --accent-strong: #7af6d6;
-  --danger: #f58f7c;
+  color-scheme: light;
+  --bg-gradient: linear-gradient(135deg, #fef4a0 0%, #ffd1dc 38%, #c7f5ff 100%);
+  --surface-primary: rgba(255, 255, 255, 0.82);
+  --surface-secondary: rgba(255, 255, 255, 0.92);
+  --surface-highlight: rgba(255, 243, 173, 0.85);
+  --border-soft: rgba(255, 255, 255, 0.65);
+  --border-strong: rgba(255, 156, 187, 0.7);
+  --text-primary: #2f2a4a;
+  --text-secondary: rgba(47, 42, 74, 0.72);
+  --accent: #ff87ab;
+  --accent-strong: #ffce6d;
+  --accent-sky: #6ed3ff;
+  --success: #4fcbb0;
 }
 
 *,
@@ -21,11 +22,36 @@
 
 body {
   margin: 0;
-  font-family: "Noto Sans JP", "Hiragino Sans", "Yu Gothic", "Segoe UI", sans-serif;
+  font-family: "M PLUS Rounded 1c", "Hiragino Maru Gothic ProN", "Yu Gothic UI", "Noto Sans JP", sans-serif;
   color: var(--text-primary);
   background: var(--bg-gradient);
   min-height: 100vh;
   line-height: 1.6;
+  position: relative;
+  overflow-x: hidden;
+}
+
+body::before,
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: -1;
+}
+
+body::before {
+  background-image: radial-gradient(circle at 10% 20%, rgba(255, 255, 255, 0.65) 0, transparent 55%),
+    radial-gradient(circle at 85% 15%, rgba(255, 255, 255, 0.5) 0, transparent 60%),
+    radial-gradient(circle at 50% 80%, rgba(255, 255, 255, 0.45) 0, transparent 65%);
+  opacity: 0.55;
+}
+
+body::after {
+  background-image: linear-gradient(135deg, rgba(255, 255, 255, 0.12) 0%, rgba(255, 255, 255, 0) 60%),
+    radial-gradient(circle at 40% 40%, rgba(255, 255, 255, 0.18) 0, transparent 55%),
+    radial-gradient(circle at 75% 70%, rgba(255, 255, 255, 0.2) 0, transparent 55%);
+  opacity: 0.4;
 }
 
 a {
@@ -36,6 +62,30 @@ main {
   display: block;
 }
 
+.ruby-inline,
+ruby {
+  ruby-position: over;
+  white-space: nowrap;
+}
+
+rt {
+  font-size: 0.58em;
+  color: var(--accent);
+  font-weight: 700;
+  letter-spacing: 0.05em;
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
 .landing {
   margin: 0 auto;
   padding: 4rem 1.5rem 5rem;
@@ -44,75 +94,159 @@ main {
 
 .hero {
   position: relative;
-  padding: 3rem clamp(1.5rem, 2vw + 1rem, 3.5rem);
-  border-radius: 24px;
-  border: 1px solid var(--border-soft);
-  background: linear-gradient(135deg, rgba(14, 50, 54, 0.8), rgba(10, 23, 26, 0.85));
+  padding: clamp(2.75rem, 6vw, 4rem);
+  border-radius: 32px;
+  border: 3px solid rgba(255, 255, 255, 0.75);
+  background: linear-gradient(125deg, rgba(255, 255, 255, 0.9) 0%, rgba(255, 230, 247, 0.9) 45%, rgba(210, 244, 255, 0.85) 100%);
   overflow: hidden;
-  box-shadow: 0 30px 50px rgba(0, 0, 0, 0.45);
-  margin-bottom: 3.5rem;
+  box-shadow: 0 30px 60px rgba(255, 170, 206, 0.35);
+}
+
+.hero__decor {
+  position: absolute;
+  inset: -40% -15% -35% -15%;
+  z-index: 0;
+}
+
+.hero__shape {
+  position: absolute;
+  border-radius: 50%;
+  opacity: 0.7;
+  filter: blur(0px);
+  mix-blend-mode: screen;
+  animation: floaty 14s ease-in-out infinite;
+}
+
+.hero__shape--one {
+  width: 380px;
+  height: 380px;
+  top: 12%;
+  left: -6%;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 207, 228, 0.85), rgba(255, 137, 171, 0.6));
+}
+
+.hero__shape--two {
+  width: 260px;
+  height: 260px;
+  right: -8%;
+  top: 48%;
+  animation-delay: -6s;
+  background: radial-gradient(circle at 50% 50%, rgba(110, 211, 255, 0.8), rgba(255, 255, 255, 0));
+}
+
+.hero__shape--three {
+  width: 220px;
+  height: 220px;
+  bottom: -8%;
+  left: 42%;
+  animation-delay: -3s;
+  background: radial-gradient(circle at 40% 40%, rgba(255, 246, 176, 0.85), rgba(255, 255, 255, 0));
 }
 
 .hero__content {
   position: relative;
   z-index: 1;
-  max-width: 38rem;
+  max-width: 40rem;
 }
 
 .hero__eyebrow {
   display: inline-flex;
   align-items: center;
-  padding: 0.35rem 0.9rem;
+  gap: 0.45rem;
+  padding: 0.5rem 1.1rem;
   border-radius: 999px;
-  border: 1px solid var(--border-strong);
-  background: rgba(14, 62, 66, 0.6);
+  background: rgba(255, 255, 255, 0.85);
+  color: var(--accent);
   font-size: 0.85rem;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
-  margin-bottom: 1.2rem;
+  font-weight: 700;
+  box-shadow: 0 15px 24px rgba(255, 135, 171, 0.25);
+}
+
+.hero__eyebrow::before {
+  content: "★";
+  font-size: 0.9rem;
+  color: var(--accent-strong);
 }
 
 .hero h1 {
-  font-size: clamp(2.4rem, 5vw, 3.4rem);
-  margin: 0 0 1rem;
+  font-size: clamp(2.6rem, 6vw, 3.6rem);
+  margin: 0 0 1.25rem;
+  line-height: 1.15;
+  font-weight: 800;
+  background: linear-gradient(90deg, #ff87ab 0%, #ffce6d 50%, #6ed3ff 100%);
+  -webkit-background-clip: text;
+  color: transparent;
+  text-shadow: 0 18px 40px rgba(255, 135, 171, 0.45);
+}
+
+.hero__sparkle {
+  display: inline-block;
+  margin-left: 0.45rem;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  color: #ffd966;
+  transform: rotate(-15deg);
+  animation: twinkle 2.4s ease-in-out infinite;
 }
 
 .hero p {
   margin: 0;
   color: var(--text-secondary);
   font-size: 1.05rem;
-}
-
-.hero__glow {
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at 20% 20%, rgba(122, 246, 214, 0.45), transparent 55%),
-    radial-gradient(circle at 80% 30%, rgba(84, 197, 210, 0.35), transparent 60%);
-  filter: blur(12px);
-  opacity: 0.8;
+  background: rgba(255, 255, 255, 0.78);
+  border-radius: 18px;
+  padding: 1.05rem 1.35rem;
+  box-shadow: 0 18px 28px rgba(110, 211, 255, 0.25);
 }
 
 .chat-section {
   position: relative;
+  margin-top: 4rem;
+}
+
+.chat-section::before {
+  content: "";
+  position: absolute;
+  inset: -4rem -12rem -6rem;
+  background: radial-gradient(circle at 30% 10%, rgba(255, 255, 255, 0.32), transparent 60%),
+    radial-gradient(circle at 80% 30%, rgba(255, 255, 255, 0.28), transparent 65%),
+    radial-gradient(circle at 50% 70%, rgba(255, 255, 255, 0.25), transparent 70%);
+  z-index: 0;
 }
 
 .chat-layout {
+  position: relative;
+  z-index: 1;
   display: grid;
   grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
-  gap: 2.5rem;
+  gap: 2.75rem;
   align-items: start;
 }
 
 .chat-window {
+  position: relative;
   background: var(--surface-secondary);
-  border-radius: 22px;
-  border: 1px solid var(--border-soft);
-  box-shadow: 0 25px 40px rgba(0, 0, 0, 0.35);
+  border-radius: 28px;
+  border: 3px solid rgba(255, 255, 255, 0.85);
+  box-shadow: 0 28px 60px rgba(255, 170, 206, 0.3);
   display: flex;
   flex-direction: column;
   min-height: 520px;
   overflow: hidden;
-  backdrop-filter: blur(16px);
+}
+
+.chat-window::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.95), rgba(255, 238, 252, 0.82));
+  z-index: 0;
+}
+
+.chat-window > * {
+  position: relative;
+  z-index: 1;
 }
 
 .chat-window__header {
@@ -120,32 +254,47 @@ main {
   justify-content: space-between;
   align-items: flex-start;
   gap: 1.5rem;
-  padding: 1.75rem 2rem 1.25rem;
-  border-bottom: 1px solid rgba(100, 212, 208, 0.2);
-  background: rgba(11, 45, 50, 0.5);
+  padding: 1.8rem 2rem 1.4rem;
+  background: linear-gradient(135deg, rgba(255, 240, 200, 0.95), rgba(255, 200, 230, 0.9));
+  border-bottom: 2px dashed rgba(255, 196, 210, 0.55);
 }
 
 .chat-window__header h2 {
-  font-size: 1.35rem;
-  margin: 0 0 0.35rem;
+  font-size: 1.45rem;
+  margin: 0 0 0.45rem;
+  color: #5b2f6f;
+  font-weight: 800;
 }
 
 .chat-window__subhead {
-  color: var(--text-secondary);
+  color: rgba(91, 47, 111, 0.72);
   margin: 0;
-  font-size: 0.95rem;
+  font-size: 0.98rem;
+  font-weight: 600;
 }
 
 .chat-window__status {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.35rem 0.9rem;
+  padding: 0.5rem 1.2rem;
   border-radius: 999px;
-  background: rgba(68, 196, 183, 0.15);
-  border: 1px solid rgba(122, 246, 214, 0.4);
-  font-size: 0.85rem;
-  letter-spacing: 0.02em;
+  background: rgba(79, 203, 176, 0.18);
+  border: 2px solid rgba(79, 203, 176, 0.35);
+  font-size: 0.9rem;
+  letter-spacing: 0.04em;
+  font-weight: 700;
+  color: #178d76;
+  box-shadow: 0 14px 24px rgba(79, 203, 176, 0.22);
+}
+
+.chat-window__status::before {
+  content: "";
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 50%;
+  background: var(--success);
+  box-shadow: 0 0 0 4px rgba(79, 203, 176, 0.18);
 }
 
 .chat-window__messages {
@@ -155,32 +304,33 @@ main {
   display: flex;
   flex-direction: column;
   gap: 1.2rem;
-  background: linear-gradient(180deg, rgba(6, 20, 22, 0.9), rgba(6, 16, 17, 0.65));
+  background: rgba(255, 255, 255, 0.75);
 }
 
 .chat-window__messages::-webkit-scrollbar {
-  width: 8px;
+  width: 10px;
 }
 
 .chat-window__messages::-webkit-scrollbar-thumb {
-  background: rgba(122, 246, 214, 0.35);
+  background: rgba(255, 135, 171, 0.35);
   border-radius: 999px;
 }
 
 .chat-window__composer {
-  padding: 1.25rem 1.5rem 1.75rem;
-  background: rgba(11, 45, 50, 0.45);
-  border-top: 1px solid rgba(122, 246, 214, 0.2);
+  padding: 1.3rem 1.6rem 1.85rem;
+  background: rgba(255, 240, 250, 0.72);
+  border-top: 2px dashed rgba(255, 196, 210, 0.55);
 }
 
 .chat-window__form {
   display: flex;
   gap: 1rem;
   align-items: center;
-  background: rgba(7, 23, 25, 0.8);
-  border-radius: 16px;
-  padding: 0.75rem 1rem;
-  border: 1px solid rgba(100, 212, 208, 0.2);
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 20px;
+  padding: 0.85rem 1rem;
+  border: 2px solid rgba(255, 196, 210, 0.65);
+  box-shadow: 0 15px 28px rgba(255, 170, 206, 0.22);
 }
 
 .chat-window__form input[type="text"] {
@@ -189,32 +339,37 @@ main {
   border: none;
   color: var(--text-primary);
   font-size: 1rem;
+  font-weight: 500;
   outline: none;
 }
 
 .chat-window__form input::placeholder {
-  color: rgba(200, 236, 235, 0.45);
+  color: rgba(91, 47, 111, 0.4);
 }
 
 .chat-window__send {
   border: none;
-  border-radius: 12px;
+  border-radius: 999px;
   background: linear-gradient(135deg, var(--accent), var(--accent-strong));
-  color: #00100f;
-  font-weight: 600;
-  padding: 0.6rem 1.4rem;
+  color: #fffaf3;
+  font-weight: 700;
+  font-size: 1rem;
+  padding: 0.65rem 1.6rem;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+  letter-spacing: 0.05em;
+  box-shadow: 0 15px 25px rgba(255, 135, 171, 0.4);
+  transition: transform 0.25s ease, box-shadow 0.25s ease, opacity 0.25s ease;
 }
 
 .chat-window__send:disabled {
-  opacity: 0.5;
+  opacity: 0.55;
   cursor: not-allowed;
+  box-shadow: none;
 }
 
 .chat-window__send:not(:disabled):hover {
-  transform: translateY(-1px);
-  box-shadow: 0 10px 20px rgba(122, 246, 214, 0.35);
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 20px 32px rgba(255, 135, 171, 0.45);
 }
 
 .message {
@@ -235,41 +390,47 @@ main {
 
 .message-bubble {
   padding: 1rem 1.2rem;
-  border-radius: 18px;
-  font-size: 0.98rem;
+  border-radius: 22px;
+  font-size: 1rem;
   letter-spacing: 0.01em;
   line-height: 1.65;
-  box-shadow: 0 18px 30px rgba(0, 0, 0, 0.35);
+  position: relative;
 }
 
 .user-message .message-bubble {
-  background: linear-gradient(135deg, rgba(122, 246, 214, 0.9), rgba(91, 205, 218, 0.85));
-  color: #002121;
+  background: linear-gradient(135deg, rgba(255, 218, 121, 0.95), rgba(255, 170, 206, 0.9));
+  color: #5b3262;
+  border-radius: 22px 22px 10px 22px;
+  box-shadow: 0 18px 28px rgba(255, 170, 206, 0.28);
 }
 
 .bot-message .message-bubble {
-  background: rgba(10, 40, 45, 0.85);
-  border: 1px solid rgba(122, 246, 214, 0.22);
-  color: var(--text-primary);
+  background: rgba(206, 243, 255, 0.92);
+  border: 2px solid rgba(110, 211, 255, 0.45);
+  color: #1d3b57;
+  border-radius: 22px 22px 22px 10px;
+  box-shadow: 0 18px 28px rgba(110, 211, 255, 0.25);
 }
 
 .message-meta {
-  font-size: 0.75rem;
-  color: rgba(214, 245, 245, 0.45);
+  font-size: 0.78rem;
+  color: rgba(47, 42, 74, 0.45);
+  font-weight: 600;
 }
 
 .typing-indicator .message-bubble {
   display: inline-flex;
-  gap: 0.4rem;
+  gap: 0.45rem;
   align-items: center;
-  background: rgba(10, 40, 45, 0.7);
+  background: rgba(206, 243, 255, 0.85);
+  border: 2px dashed rgba(110, 211, 255, 0.45);
 }
 
 .typing-dot {
-  width: 0.55rem;
-  height: 0.55rem;
+  width: 0.6rem;
+  height: 0.6rem;
   border-radius: 50%;
-  background: rgba(122, 246, 214, 0.6);
+  background: rgba(110, 211, 255, 0.8);
   animation: blink 1.4s infinite ease-in-out;
 }
 
@@ -279,6 +440,78 @@ main {
 
 .typing-dot:nth-child(3) {
   animation-delay: 0.4s;
+}
+
+.chat-tips {
+  position: relative;
+  background: var(--surface-primary);
+  border-radius: 28px;
+  padding: 2.5rem 2.2rem;
+  border: 3px solid rgba(255, 255, 255, 0.85);
+  box-shadow: 0 30px 60px rgba(110, 211, 255, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+  overflow: hidden;
+}
+
+.chat-tips::before {
+  content: "";
+  position: absolute;
+  inset: -40% -30% auto -20%;
+  height: 70%;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 206, 227, 0.6), transparent 60%);
+  pointer-events: none;
+}
+
+.chat-tips h3 {
+  margin: 0;
+  font-size: 1.3rem;
+  font-weight: 800;
+  color: #5b2f6f;
+  background: linear-gradient(90deg, #ff87ab, #6ed3ff);
+  -webkit-background-clip: text;
+  color: transparent;
+}
+
+.chat-tips ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+  color: var(--text-primary);
+}
+
+.chat-tips li {
+  position: relative;
+  padding: 1rem 1.25rem 1rem 2.6rem;
+  background: rgba(255, 255, 255, 0.72);
+  border-radius: 20px;
+  box-shadow: 0 15px 25px rgba(110, 211, 255, 0.22);
+}
+
+.chat-tips li::before {
+  content: "";
+  position: absolute;
+  left: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 1.35rem;
+  height: 1.35rem;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent), var(--accent-sky));
+  box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.7);
+}
+
+.chat-tips__footer {
+  font-size: 0.88rem;
+  color: rgba(47, 42, 74, 0.6);
+  line-height: 1.6;
+  background: rgba(255, 255, 255, 0.7);
+  padding: 0.9rem 1.1rem;
+  border-radius: 16px;
+  box-shadow: 0 12px 24px rgba(255, 206, 227, 0.2);
 }
 
 @keyframes blink {
@@ -294,46 +527,26 @@ main {
   }
 }
 
-.chat-tips {
-  background: var(--surface-primary);
-  border-radius: 22px;
-  padding: 2.25rem;
-  border: 1px solid var(--border-soft);
-  box-shadow: 0 25px 45px rgba(0, 0, 0, 0.35);
-  backdrop-filter: blur(18px);
-  display: flex;
-  flex-direction: column;
-  gap: 1.2rem;
+@keyframes floaty {
+  0%,
+  100% {
+    transform: translateY(0) scale(1);
+  }
+  50% {
+    transform: translateY(-20px) scale(1.05);
+  }
 }
 
-.chat-tips h3 {
-  margin: 0;
-  font-size: 1.2rem;
-}
-
-.chat-tips ul {
-  margin: 0;
-  padding-left: 1.2rem;
-  color: var(--text-secondary);
-  display: grid;
-  gap: 0.75rem;
-}
-
-.chat-tips__footer {
-  font-size: 0.85rem;
-  color: rgba(216, 240, 239, 0.6);
-  line-height: 1.5;
-}
-
-.visually-hidden {
-  position: absolute !important;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  border: 0;
+@keyframes twinkle {
+  0%,
+  100% {
+    transform: rotate(-15deg) scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: rotate(-15deg) scale(1.15);
+    opacity: 0.6;
+  }
 }
 
 @media (max-width: 960px) {
@@ -345,22 +558,36 @@ main {
     grid-template-columns: 1fr;
   }
 
-  .chat-window {
-    min-height: 480px;
+  .chat-section::before {
+    inset: -3rem -8rem -4rem;
+  }
+
+  .chat-window,
+  .chat-tips {
+    box-shadow: 0 20px 45px rgba(110, 211, 255, 0.25);
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width: 680px) {
   .hero {
-    padding: 2.5rem 1.75rem;
+    padding: 2.5rem 1.85rem;
+    border-radius: 26px;
+  }
+
+  .hero__decor {
+    inset: -55% -25% -45% -25%;
   }
 
   .chat-window__header {
-    padding: 1.5rem 1.5rem 1.1rem;
+    padding: 1.6rem 1.5rem 1.2rem;
   }
 
   .chat-window__messages {
-    padding: 1.5rem;
+    padding: 1.6rem;
+  }
+
+  .chat-window__composer {
+    padding: 1.1rem 1.3rem 1.6rem;
   }
 
   .chat-window__form {

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,16 +1,31 @@
-<% content_for :title, "寄生虫チャットボット" %>
+<% content_for :title, "寄生虫（きせいちゅう）チャットボット" %>
 
 <main class="landing">
   <section class="hero">
+    <div class="hero__decor" aria-hidden="true">
+      <span class="hero__shape hero__shape--one"></span>
+      <span class="hero__shape hero__shape--two"></span>
+      <span class="hero__shape hero__shape--three"></span>
+    </div>
     <div class="hero__content">
       <span class="hero__eyebrow">Parasite Navigator</span>
-      <h1>寄生虫チャットボット</h1>
+      <h1>
+        <ruby><rb>寄生虫</rb><rt>きせいちゅう</rt></ruby>
+        チャットボット
+        <span class="hero__sparkle" aria-hidden="true">★</span>
+      </h1>
       <p>
-        寄生虫の世界を案内するバーチャルアシスタントです。生活環、感染経路、予防策など、
-        気になることを何でも質問してください。怖いだけじゃない寄生虫の生態を、好奇心と科学で紐解きましょう。
+        <ruby><rb>寄生虫</rb><rt>きせいちゅう</rt></ruby>の<ruby><rb>世界</rb><rt>せかい</rt></ruby>を
+        <ruby><rb>案内</rb><rt>あんない</rt></ruby>するバーチャルアシスタントです。
+        <ruby><rb>生活環</rb><rt>せいかつかん</rt></ruby>や<ruby><rb>感染</rb><rt>かんせん</rt></ruby>の
+        <ruby><rb>経路</rb><rt>けいろ</rt></ruby>、<ruby><rb>予防策</rb><rt>よぼうさく</rt></ruby>など、
+        <ruby><rb>気</rb><rt>き</rt></ruby>になることをなんでも<ruby><rb>質問</rb><rt>しつもん</rt></ruby>してね。
+        <ruby><rb>怖い</rb><rt>こわい</rt></ruby>だけじゃない
+        <ruby><rb>寄生虫</rb><rt>きせいちゅう</rt></ruby>の<ruby><rb>生態</rb><rt>せいたい</rt></ruby>を、
+        <ruby><rb>好奇心</rb><rt>こうきしん</rt></ruby>と<ruby><rb>科学</rb><rt>かがく</rt></ruby>で
+        <ruby><rb>紐解</rb><rt>ひもと</rt></ruby>いていきましょう。
       </p>
     </div>
-    <div class="hero__glow" aria-hidden="true"></div>
   </section>
 
   <section class="chat-section" aria-labelledby="chatbot-heading">
@@ -18,35 +33,69 @@
       <div class="chat-window" data-controller="chat">
         <div class="chat-window__header">
           <div>
-            <h2 id="chatbot-heading">寄生虫コンシェルジュ</h2>
-            <p class="chat-window__subhead">寄生虫博士の視点からリアルタイムでガイドします。</p>
+            <h2 id="chatbot-heading">
+              <ruby><rb>寄生虫</rb><rt>きせいちゅう</rt></ruby>
+              <ruby><rb>コンシェルジュ</rb><rt>こんしぇるじゅ</rt></ruby>
+            </h2>
+            <p class="chat-window__subhead">
+              <ruby><rb>寄生虫</rb><rt>きせいちゅう</rt></ruby>
+              <ruby><rb>博士</rb><rt>はかせ</rt></ruby>の<ruby><rb>視点</rb><rt>してん</rt></ruby>から
+              リアルタイムでガイドします。
+            </p>
           </div>
           <span class="chat-window__status" data-chat-target="status">オンライン</span>
         </div>
         <div class="chat-window__messages" data-chat-target="messages" aria-live="polite"></div>
         <div class="chat-window__composer">
           <form data-action="submit->chat#submit" class="chat-window__form" autocomplete="off">
-            <label for="chat-input" class="visually-hidden">質問を入力</label>
+            <label for="chat-input" class="visually-hidden">しつもんをいれてね</label>
             <input
               id="chat-input"
               type="text"
-              placeholder="例：魚から感染する寄生虫は？"
+              placeholder="れい：さかなからうつるきせいちゅうは？"
               data-chat-target="input"
-              aria-label="寄生虫チャットボットへの質問"
+              aria-label="きせいちゅうちゃっとぼっとへのしつもん"
             >
-            <button type="submit" class="chat-window__send" data-chat-target="send">送信</button>
+            <button type="submit" class="chat-window__send" data-chat-target="send">おくる</button>
           </form>
         </div>
       </div>
 
-      <aside class="chat-tips" aria-label="寄生虫の豆知識">
-        <h3>寄生虫の豆知識</h3>
+      <aside class="chat-tips" aria-label="きせいちゅうのまめちしき">
+        <h3>
+          <ruby><rb>寄生虫</rb><rt>きせいちゅう</rt></ruby>の
+          <ruby><rb>豆知識</rb><rt>まめちしき</rt></ruby>
+        </h3>
         <ul>
-          <li>寄生虫は宿主から栄養を得る生物で、医療・生態学の重要な研究対象です。</li>
-          <li>加熱や冷凍など正しい食品管理で、多くの寄生虫感染を防ぐことができます。</li>
-          <li>一部の寄生虫は宿主の行動を巧みに操ることで生存戦略を成功させます。</li>
+          <li>
+            <ruby><rb>寄生虫</rb><rt>きせいちゅう</rt></ruby>は
+            <ruby><rb>宿主</rb><rt>やどぬし</rt></ruby>から<ruby><rb>栄養</rb><rt>えいよう</rt></ruby>を
+            <ruby><rb>得</rb><rt>え</rt></ruby>る<ruby><rb>生物</rb><rt>せいぶつ</rt></ruby>で、
+            <ruby><rb>医療</rb><rt>いりょう</rt></ruby>・<ruby><rb>生態学</rb><rt>せいたいがく</rt></ruby>の
+            <ruby><rb>重要</rb><rt>じゅうよう</rt></ruby>な<ruby><rb>研究対象</rb><rt>けんきゅうたいしょう</rt></ruby>です。
+          </li>
+          <li>
+            <ruby><rb>加熱</rb><rt>かねつ</rt></ruby>や<ruby><rb>冷凍</rb><rt>れいとう</rt></ruby>など
+            <ruby><rb>正</rb><rt>ただ</rt></ruby>しい<ruby><rb>食品管理</rb><rt>しょくひんかんり</rt></ruby>で、
+            たくさんの<ruby><rb>寄生虫</rb><rt>きせいちゅう</rt></ruby><ruby><rb>感染</rb><rt>かんせん</rt></ruby>を
+            <ruby><rb>防</rb><rt>ふせ</rt></ruby>ぐことができます。
+          </li>
+          <li>
+            <ruby><rb>一部</rb><rt>いちぶ</rt></ruby>の
+            <ruby><rb>寄生虫</rb><rt>きせいちゅう</rt></ruby>は<ruby><rb>宿主</rb><rt>やどぬし</rt></ruby>の
+            <ruby><rb>行動</rb><rt>こうどう</rt></ruby>を<ruby><rb>巧</rb><rt>たく</rt></ruby>みに
+            <ruby><rb>操</rb><rt>あやつ</rt></ruby>って
+            <ruby><rb>生存戦略</rb><rt>せいぞんせんりゃく</rt></ruby>を
+            <ruby><rb>成功</rb><rt>せいこう</rt></ruby>させます。
+          </li>
         </ul>
-        <p class="chat-tips__footer">チャットでの回答は教育目的です。体調に不安がある場合は医療機関に相談しましょう。</p>
+        <p class="chat-tips__footer">
+          チャットでの<ruby><rb>回答</rb><rt>かいとう</rt></ruby>は
+          <ruby><rb>教育目的</rb><rt>きょういくもくてき</rt></ruby>です。
+          <ruby><rb>体調</rb><rt>たいちょう</rt></ruby>に<ruby><rb>不安</rb><rt>ふあん</rt></ruby>があるときは
+          <ruby><rb>医療機関</rb><rt>いりょうきかん</rt></ruby>に
+          <ruby><rb>相談</rb><rt>そうだん</rt></ruby>しましょう。
+        </p>
       </aside>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- refresh the landing and chat layout with a playful, kid-friendly color palette and decorative elements
- add furigana markup and hiragana labels for all Japanese text so young readers can follow along

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cba7821d308322bb18903c09f6fc99