### PR TITLE
Improve responsive layout for landing page

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -88,7 +88,7 @@ rt {
 
 .landing {
   margin: 0 auto;
-  padding: 4rem 1.5rem 5rem;
+  padding: clamp(3rem, 6vw, 4rem) clamp(1.1rem, 4vw, 1.5rem) clamp(3.5rem, 8vw, 5rem);
   max-width: 1100px;
 }
 
@@ -551,11 +551,12 @@ rt {
 
 @media (max-width: 960px) {
   .landing {
-    padding-top: 3.5rem;
+    padding-top: clamp(2.5rem, 7vw, 3.5rem);
   }
 
   .chat-layout {
     grid-template-columns: 1fr;
+    gap: 2rem;
   }
 
   .chat-section::before {
@@ -578,8 +579,24 @@ rt {
     inset: -55% -25% -45% -25%;
   }
 
+  .hero__content {
+    text-align: center;
+    margin-inline: auto;
+  }
+
+  .hero__eyebrow {
+    margin-inline: auto;
+  }
+
+  .hero p {
+    font-size: 0.98rem;
+    text-align: left;
+  }
+
   .chat-window__header {
     padding: 1.6rem 1.5rem 1.2rem;
+    flex-direction: column;
+    gap: 1rem;
   }
 
   .chat-window__messages {
@@ -593,9 +610,163 @@ rt {
   .chat-window__form {
     flex-direction: column;
     align-items: stretch;
+    gap: 0.85rem;
   }
 
   .chat-window__send {
     width: 100%;
+  }
+
+  .chat-window__status {
+    align-self: flex-start;
+    justify-content: center;
+  }
+
+  .chat-layout {
+    gap: 1.6rem;
+  }
+
+  .chat-tips {
+    padding: 2.1rem 1.85rem;
+    gap: 1.15rem;
+  }
+}
+
+@media (max-width: 520px) {
+  .landing {
+    padding-inline: clamp(0.9rem, 6vw, 1.25rem);
+  }
+
+  .hero {
+    padding: 2.1rem 1.55rem;
+  }
+
+  .hero h1 {
+    font-size: clamp(2.2rem, 9vw, 2.8rem);
+  }
+
+  .hero__decor {
+    inset: -65% -38% -55% -38%;
+  }
+
+  .hero p {
+    font-size: 0.94rem;
+    padding: 0.95rem 1.1rem;
+  }
+
+  .chat-section {
+    margin-top: 3rem;
+  }
+
+  .chat-window {
+    min-height: 420px;
+  }
+
+  .chat-window__header h2 {
+    font-size: 1.32rem;
+  }
+
+  .chat-window__subhead {
+    font-size: 0.94rem;
+  }
+
+  .chat-window__messages {
+    padding: 1.3rem;
+    gap: 1rem;
+  }
+
+  .chat-window__composer {
+    padding: 1rem 1.1rem 1.5rem;
+  }
+
+  .chat-window__form {
+    padding: 0.8rem 0.9rem;
+    gap: 0.75rem;
+  }
+
+  .chat-window__form input[type="text"] {
+    font-size: 0.98rem;
+  }
+
+  .chat-window__send {
+    padding: 0.6rem 1.4rem;
+  }
+
+  .chat-tips {
+    padding: 1.9rem 1.6rem;
+  }
+
+  .chat-tips ul {
+    gap: 0.85rem;
+  }
+
+  .chat-tips li {
+    padding: 0.95rem 1.1rem 0.95rem 2.3rem;
+  }
+
+  .chat-tips__footer {
+    font-size: 0.84rem;
+  }
+}
+
+@media (max-width: 420px) {
+  body {
+    line-height: 1.55;
+  }
+
+  .landing {
+    padding-top: clamp(2.2rem, 8vw, 2.8rem);
+    padding-bottom: clamp(3rem, 10vw, 4rem);
+  }
+
+  .hero {
+    border-radius: 22px;
+  }
+
+  .hero__eyebrow {
+    font-size: 0.78rem;
+    padding: 0.45rem 1rem;
+  }
+
+  .hero h1 {
+    font-size: clamp(1.95rem, 10vw, 2.4rem);
+  }
+
+  .hero p {
+    font-size: 0.9rem;
+  }
+
+  .chat-window {
+    border-radius: 24px;
+    min-height: 380px;
+  }
+
+  .chat-window__header h2 {
+    font-size: 1.24rem;
+  }
+
+  .chat-window__messages {
+    padding: 1.15rem;
+  }
+
+  .chat-window__form {
+    padding: 0.75rem 0.85rem;
+  }
+
+  .chat-window__send {
+    padding: 0.55rem 1.2rem;
+    font-size: 0.96rem;
+  }
+
+  .message {
+    max-width: 100%;
+  }
+
+  .chat-tips {
+    border-radius: 24px;
+  }
+
+  .chat-tips li::before {
+    left: 0.85rem;
   }
 }


### PR DESCRIPTION
## Summary
- adjust landing page container spacing to scale fluidly across viewport sizes
- refine tablet and mobile layouts for hero, chat window, and tips sections with focused breakpoints
- tune typography, padding, and component sizing to keep the chat experience readable on narrow screens

## Testing
- `bin/rails test` *(fails: missing required gems in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbac9d476c8322850849e64c4d37d3